### PR TITLE
Compiling with clang under osx

### DIFF
--- a/include/tensor/numbers.h
+++ b/include/tensor/numbers.h
@@ -26,9 +26,8 @@
 
 namespace tensor {
 
-using std::conj;
-using std::real;
 using std::imag;
+using std::real;
 using std::abs;
 
 //
@@ -42,8 +41,6 @@ template<typename number>
 inline number number_one() { return static_cast<number>(1); }
 
 /* Already in C++11 but they return complex */
-inline double real(double r) { return r; }
-inline double imag(double r) { return 0.0; }
 inline double conj(double r) { return r; }
 inline double abs2(double r) { return r*r; }
 
@@ -55,6 +52,8 @@ inline number square(number r) { return r*r; }
 //
 
 typedef std::complex<double> cdouble;
+
+inline cdouble conj(const cdouble &r) { return std::conj(r); }
 
 inline cdouble to_complex(const double &r) {
   return cdouble(r, 0);

--- a/include/tensor/tensor_blas.h
+++ b/include/tensor/tensor_blas.h
@@ -34,12 +34,7 @@
 #endif
 
 #ifdef TENSOR_USE_VECLIB
-# if defined(HAVE_VECLIB_CBLAS_H)
-#  include <vecLib/cblas.h>
-#  include <vecLib/clapack.h>
-# else
-#  error "Missing cblas.h"
-# endif
+# include <Accelerate/accelerate.h>
 # define F77NAME(x) x##_
 #endif
 

--- a/m4/tensor.m4
+++ b/m4/tensor.m4
@@ -31,11 +31,11 @@ dnl ----------------------------------------------------------------------
 dnl Find veclib framework
 dnl
 AC_DEFUN([TENSOR_VECLIB],[
-  AC_MSG_CHECKING([for VecLib library])
+  AC_MSG_CHECKING([for Accelerate library])
   if test `uname` = "Darwin"; then
     have_veclib=yes
-    VECLIB_LIBS="-framework veclib"
-    AC_CHECK_HEADERS_ONCE([vecLib/cblas.h])
+    VECLIB_LIBS="-framework Accelerate"
+    AC_CHECK_HEADERS_ONCE([Accelerate/accelerate.h])
   else
     have_veclib=no
   fi


### PR DESCRIPTION
The current version of this library does not compile cleanly under a recent version of OSX (I am using Yosemite 10.10). This is why:

1. VecLib framework has been included/renamed into Accelerate framework, so that the current headers check was failing.
2. numbers.h does something that clang does not seem to like (I suspect it is not correct C++): it imports some template functions from the standard library, but then it tries to overload them using the same function signature. Obviously this fails with a "error: declaration conflicts with target of using declaration already in scope".

So what I have done:

1. changed the preprocessing and include statements to refer to Accelerate instead of veclib
2. stopped importing std::conj, and instead defining the two versions (real and complex). std::real and std::imag are already returning a double, so I do not understand why they have been re-defined: I have removed the inline definitions.

While it does not create definition conflicts, abs2 seems only to be used here, not anywhere else in the library, and std::abs also returns a double: what is the reason for it?